### PR TITLE
Add `--preview-status` and `--force-refresh` CLI options to preview board renders

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ Live update:
 python -m fpv_board.main --config /opt/fpv-board/fpv_board/config.json
 ```
 
+Preview alternate board renders immediately (without waiting for weather/condition changes):
+
+```bash
+python -m fpv_board.main --config /opt/fpv-board/fpv_board/config.json --preview-status NOPE --force-refresh
+```
+
+You can use `--preview-status` with `GREAT`, `OK`, `MARGINAL`, or `NOPE` to test each visual state.
+
 ## systemd setup
 
 ```bash

--- a/fpv_board/main.py
+++ b/fpv_board/main.py
@@ -397,7 +397,17 @@ def show_on_epaper(black: Image.Image, red: Image.Image, model_path: str) -> Non
     epd.sleep()
 
 
-def run(config_path: Path, dry_run: bool) -> int:
+def apply_preview_status(result: dict[str, Any], preview_status: str | None) -> dict[str, Any]:
+    if not preview_status:
+        return result
+    preview_result = dict(result)
+    preview_result["status"] = preview_status
+    preview_result["reason"] = f"Preview mode: forced {preview_status}"
+    preview_result["trend"] = "Preview render"
+    return preview_result
+
+
+def run(config_path: Path, dry_run: bool, preview_status: str | None, force_refresh: bool) -> int:
     cfg = load_config(config_path)
     setup_logging(Path(cfg["state"]["log_file"]))
 
@@ -422,11 +432,12 @@ def run(config_path: Path, dry_run: bool) -> int:
     )
 
     result = evaluate(selected, cfg)
+    result = apply_preview_status(result, preview_status)
     display_state = build_display_state(result, cfg)
 
     cache_file = Path(cfg["state"]["cache_file"])
     previous_state = load_previous_state(cache_file)
-    changed = not states_equal(previous_state, display_state)
+    changed = force_refresh or bool(preview_status) or (not states_equal(previous_state, display_state))
 
     black, red = render_image(result, now, cfg)
 
@@ -451,13 +462,23 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="FPV Flight Board updater")
     parser.add_argument("--config", default="/opt/fpv-board/fpv_board/config.json", help="Path to config file")
     parser.add_argument("--dry-run", action="store_true", help="Print computed output without touching display")
+    parser.add_argument(
+        "--preview-status",
+        choices=["GREAT", "OK", "MARGINAL", "NOPE"],
+        help="Force a rendered status so you can preview alternate board images immediately",
+    )
+    parser.add_argument(
+        "--force-refresh",
+        action="store_true",
+        help="Refresh display even when change detection says nothing meaningful changed",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
     try:
-        raise SystemExit(run(Path(args.config), args.dry_run))
+        raise SystemExit(run(Path(args.config), args.dry_run, args.preview_status, args.force_refresh))
     except Exception as exc:  # deliberate top-level guard for service reliability
         logging.exception("Fatal error: %s", exc)
         raise


### PR DESCRIPTION
### Motivation
- Provide an operator-friendly way to immediately preview how each board state is rendered without waiting for forecast or cache changes.
- Allow forcing a refresh even when the change-detection would normally skip an update so visual checks can be performed on-demand.

### Description
- Add `apply_preview_status(result, preview_status)` to override the computed `status`, `reason`, and `trend` when a preview is requested.
- Extend `run(...)` signature to accept `preview_status` and `force_refresh`, apply the preview override before rendering, and include preview/force in change detection.
- Add CLI flags `--preview-status` (choices: `GREAT`, `OK`, `MARGINAL`, `NOPE`) and `--force-refresh` and wire them through the program entrypoint.
- Document the new workflow in `README.md` including an example command to preview renders: `python -m fpv_board.main --config /opt/fpv-board/fpv_board/config.json --preview-status NOPE --force-refresh`.

### Testing
- Verified CLI help with `python -m fpv_board.main --help`, which listed the new `--preview-status` and `--force-refresh` options, and the command returned successfully. (succeeded)
- Performed a dry-run invocation path during development to ensure the preview branch is exercised by the runtime logic (manual validation during rollout; no automated unit tests were present). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69992b94ab3483208af3bd5949061450)