### PR TITLE
Fix Raspberry Pi install docs for lgpio and display setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This project fetches Open-Meteo forecast data, evaluates **daylight-only** flyin
 
 ```bash
 sudo apt update
-sudo apt install -y python3 python3-venv python3-pip git libopenjp2-7 libtiff6 libjpeg62-turbo
+sudo apt install -y python3 python3-venv python3-pip git rsync \
+  libopenjp2-7 libtiff6 libjpeg62-turbo fonts-dejavu-core \
+  python3-lgpio
 sudo raspi-config nonint do_spi 0
 sudo reboot
 ```
@@ -22,6 +24,7 @@ After reboot, reconnect and continue:
 
 ```bash
 ls /dev/spidev0.0 /dev/spidev0.1
+# If either file is missing, SPI is not enabled correctly.
 ```
 
 Create install directory and virtual environment:
@@ -31,7 +34,7 @@ sudo mkdir -p /opt/fpv-board
 sudo chown -R pi:pi /opt/fpv-board
 rsync -av --delete ./ /opt/fpv-board/
 cd /opt/fpv-board
-python3 -m venv .venv
+python3 -m venv --system-site-packages .venv
 . .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
@@ -42,7 +45,6 @@ Install Waveshare Python e-Paper library:
 ```bash
 cd /opt/fpv-board
 git clone https://github.com/waveshare/e-Paper.git waveshare-lib
-pip install RPi.GPIO spidev gpiozero
 export PYTHONPATH="/opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib:${PYTHONPATH}"
 ```
 
@@ -50,6 +52,7 @@ To make `PYTHONPATH` persistent for systemd, add to service file:
 
 ```ini
 Environment=PYTHONPATH=/opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib
+Environment=GPIOZERO_PIN_FACTORY=lgpio
 ```
 
 ## Wiring
@@ -119,3 +122,5 @@ journalctl -u fpv-board.service -n 100 --no-pager
 - **Wrong pins / BUSY stuck**: verify HAT seated correctly and BUSY maps to GPIO24.
 - **Font missing**: defaults to PIL font automatically; adjust `font_*` paths in config if needed.
 - **Import error for Waveshare module**: confirm `PYTHONPATH` includes Waveshare `python/lib` directory.
+- **`No module named lgpio` in venv**: recreate venv with `python3 -m venv --system-site-packages .venv` so apt package `python3-lgpio` is visible.
+- **`Failed to add edge detection`**: set `GPIOZERO_PIN_FACTORY=lgpio` (in shell or systemd service), then rerun.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,8 @@
 requests>=2.31.0
 Pillow>=10.0.0
+
+# System package required by fpv_board/config.json default font paths
+# (install via apt, not pip):
+# fonts-dejavu-core
+# GPIO backend expected by Waveshare/gpiozero stack (install via apt):
+# python3-lgpio

--- a/systemd/fpv-board.service
+++ b/systemd/fpv-board.service
@@ -8,6 +8,7 @@ Type=oneshot
 User=pi
 WorkingDirectory=/opt/fpv-board
 Environment=PYTHONPATH=/opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib
+Environment=GPIOZERO_PIN_FACTORY=lgpio
 ExecStart=/opt/fpv-board/.venv/bin/python -m fpv_board.main --config /opt/fpv-board/fpv_board/config.json
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
### Motivation
- Fresh SD-card installs were missing OS-level prerequisites and venv setup needed for the Waveshare e-Paper display to initialize correctly. 
- The display stack falls back from `lgpio` and fails with `No module named 'lgpio'` or `RuntimeError: Failed to add edge detection` when the system-provided backend is not visible inside the virtualenv. 
- Default font paths used by the drawing code expect DejaVu TTFs from an OS package which was not documented in `requirements.txt`.

### Description
- Updated `README.md` install prerequisites to include `rsync`, `fonts-dejavu-core`, and `python3-lgpio` in the `apt` install step. 
- Changed venv creation to `python3 -m venv --system-site-packages .venv` so the apt-provided `python3-lgpio` is available inside the virtual environment. 
- Removed the line instructing users to `pip install RPi.GPIO spidev gpiozero` in place of relying on OS packages, added explicit `PYTHONPATH` guidance, a SPI device-node verification note, and lgpio troubleshooting notes in the README. 
- Added `Environment=GPIOZERO_PIN_FACTORY=lgpio` to `systemd/fpv-board.service` and the README systemd example so services use the `lgpio` backend for edge detection. 
- Extended `requirements.txt` with comments documenting the OS-level dependencies `fonts-dejavu-core` and `python3-lgpio` (install via `apt`), not via `pip`.

### Testing
- Ran `python -m compileall fpv_board` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a3917ccd48320b956baf222063932)