### PR TITLE
Fix pre-sunrise daylight window handling

### DIFF
--- a/fpv_board/main.py
+++ b/fpv_board/main.py
@@ -135,7 +135,7 @@ def parse_hourly(data: dict[str, Any]) -> tuple[list[HourlyPoint], list[datetime
 
 def next_daylight_window(now: datetime, sunrise: list[datetime], sunset: list[datetime]) -> tuple[datetime, datetime] | None:
     for rise, set_ in zip(sunrise, sunset):
-        if now <= set_:
+        if rise <= now <= set_:
             return rise, set_
     return None
 


### PR DESCRIPTION
### Motivation
- Prevent pre-sunrise times from being treated as daytime by ensuring the daylight window is only returned when `now` falls between `sunrise` and `sunset`.

### Description
- Change `next_daylight_window` to return a window only when `rise <= now <= set_` instead of the previous `now <= set_` check so overnight hours (e.g. 3am) are treated as night.

### Testing
- Ran `python -m py_compile fpv_board/main.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a7cd8aac083209c8ff191f12d4d74)