### PR TITLE
Handle missing daylight window in eval point selection

### DIFF
--- a/fpv_board/main.py
+++ b/fpv_board/main.py
@@ -147,8 +147,12 @@ def select_eval_points(
     daylight_only: bool,
     hours_ahead: int,
 ) -> list[HourlyPoint]:
-    end = now.timestamp() + (hours_ahead * 3600)
-    selected = [p for p in points if now <= p.timestamp and p.timestamp.timestamp() <= end]
+    end = now + timedelta(hours=hours_ahead)
+    selected = [p for p in points if now <= p.timestamp <= end]
+
+    if daylight_only and daylight_window is None:
+        return []
+
     if daylight_only and daylight_window:
         rise, set_ = daylight_window
         selected = [p for p in selected if rise <= p.timestamp <= set_]


### PR DESCRIPTION
### Motivation
- Ensure `select_eval_points` correctly handles the case where `daylight_only` is requested but no `daylight_window` was returned so downstream logic (including `evaluate([])`) still sees an empty list and produces the night/no-daylight reason.

### Description
- Change `select_eval_points` to compute the end bound as a `datetime` (`now + timedelta(hours=hours_ahead)`) and keep the inclusive filter form `now <= p.timestamp <= end` when selecting points.
- Add an early guard that returns an empty list when `daylight_only` is true and `daylight_window` is `None`, while preserving the existing daylight-window filtering when a window exists.

### Testing
- Ran `python -m py_compile fpv_board/main.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a82d916d08320a398638705409f75)