### PR TITLE
Improve Waveshare module path detection and setup troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Install Waveshare Python e-Paper library:
 ```bash
 cd /opt/fpv-board
 # Clone only if the folder is not already present in your checkout
-[ -d waveshare-lib ] || git clone https://github.com/waveshare/e-Paper.git waveshare-lib
+[ -d waveshare-lib ] || [ -d e-Paper ] || git clone https://github.com/waveshare/e-Paper.git waveshare-lib
 
-# Optional for interactive troubleshooting; the app now auto-detects this bundled path when present
+# Optional for interactive troubleshooting; the app auto-detects waveshare-lib and e-Paper clone paths when present
 export PYTHONPATH="/opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib:${PYTHONPATH}"
 
 # Quick verification: should print a module path, not an import error
@@ -149,6 +149,18 @@ journalctl -u fpv-board.service -n 100 --no-pager
 - **Do not run `pip install lgpio`**: this project uses the Raspberry Pi OS package `python3-lgpio`; pip builds often fail and are unnecessary here.
 - **Wrong pins / BUSY stuck**: verify HAT seated correctly and BUSY maps to GPIO24.
 - **Font missing**: defaults to PIL font automatically; adjust `font_*` paths in config if needed.
-- **Import error for Waveshare module**: confirm `waveshare-lib/RaspberryPi_JetsonNano/python/lib` exists under `/opt/fpv-board` (auto-detected by the app). If running ad-hoc import checks, also export `PYTHONPATH` and run `python -c "import waveshare_epd; print(waveshare_epd.__file__)"`.
+- **Import error for Waveshare module**: confirm either `waveshare-lib/RaspberryPi_JetsonNano/python/lib` or `e-Paper/RaspberryPi_JetsonNano/python/lib` exists under `/opt/fpv-board` (both are auto-detected by the app). If running ad-hoc import checks, also export `PYTHONPATH` and run `python -c "import waveshare_epd; print(waveshare_epd.__file__)"`.
+- **`ModuleNotFoundError: No module named waveshare_epd` despite exported `PYTHONPATH`**: verify there is no newline in your export command and the path exists exactly:
+  ```bash
+  test -d /opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib || \
+  test -d /opt/fpv-board/e-Paper/RaspberryPi_JetsonNano/python/lib
+  python - <<'PY'
+import sys
+print("python:", sys.executable)
+print("has waveshare path:", [p for p in sys.path if "RaspberryPi_JetsonNano/python/lib" in p])
+import waveshare_epd
+print("waveshare_epd:", waveshare_epd.__file__)
+PY
+  ```
 - **`No module named lgpio` in venv**: recreate venv with `python3 -m venv --system-site-packages .venv` so apt package `python3-lgpio` is visible. Also remove pip-installed swig wrappers if present (`pip uninstall -y swig`), because they can shadow `/usr/bin/swig` during builds.
 - **`Failed to add edge detection`**: ensure no duplicate process is already using GPIO, then set `GPIOZERO_PIN_FACTORY=lgpio` (in shell or systemd service) and rerun.

--- a/fpv_board/main.py
+++ b/fpv_board/main.py
@@ -461,11 +461,21 @@ def states_equal(a: dict[str, Any] | None, b: dict[str, Any]) -> bool:
     return a == b
 
 
-def ensure_waveshare_path() -> None:
-    bundled_lib = Path(__file__).resolve().parent.parent / "waveshare-lib" / "RaspberryPi_JetsonNano" / "python" / "lib"
-    bundled_lib_str = str(bundled_lib)
-    if bundled_lib.exists() and bundled_lib_str not in sys.path:
-        sys.path.insert(0, bundled_lib_str)
+def _waveshare_lib_candidates() -> list[Path]:
+    project_root = Path(__file__).resolve().parent.parent
+    repo_names = ("waveshare-lib", "e-Paper")
+    suffix = Path("RaspberryPi_JetsonNano") / "python" / "lib"
+    return [project_root / repo_name / suffix for repo_name in repo_names]
+
+
+def ensure_waveshare_path() -> list[str]:
+    added_paths: list[str] = []
+    for candidate in _waveshare_lib_candidates():
+        candidate_str = str(candidate)
+        if candidate.exists() and candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+            added_paths.append(candidate_str)
+    return added_paths
 
 
 def show_on_epaper(black: Image.Image, red: Image.Image, model_path: str) -> None:
@@ -474,10 +484,11 @@ def show_on_epaper(black: Image.Image, red: Image.Image, model_path: str) -> Non
     try:
         module = __import__(mod_name, fromlist=[attr_name])
     except ModuleNotFoundError as exc:
+        candidate_paths = ", ".join(str(path) for path in _waveshare_lib_candidates())
         raise RuntimeError(
             "Could not import Waveshare driver module. Ensure waveshare-lib is cloned at "
-            "/opt/fpv-board/waveshare-lib or set PYTHONPATH to include "
-            "waveshare-lib/RaspberryPi_JetsonNano/python/lib."
+            f"one of: {candidate_paths} or set PYTHONPATH to include "
+            "<waveshare-clone>/RaspberryPi_JetsonNano/python/lib."
         ) from exc
     epd_factory = getattr(module, attr_name)
     epd = epd_factory() if callable(epd_factory) else getattr(epd_factory, "EPD")()

--- a/fpv_board/shutdown.py
+++ b/fpv_board/shutdown.py
@@ -7,13 +7,14 @@ import logging
 import subprocess
 from pathlib import Path
 
-from fpv_board.main import load_config, setup_logging
+from fpv_board.main import ensure_waveshare_path, load_config, setup_logging
 
 
 DEFAULT_CONFIG_PATH = Path("/opt/fpv-board/fpv_board/config.json")
 
 
 def clear_display(model_path: str) -> None:
+    ensure_waveshare_path()
     mod_name, attr_name = model_path.rsplit(".", 1)
     module = __import__(mod_name, fromlist=[attr_name])
     epd_factory = getattr(module, attr_name)


### PR DESCRIPTION
### Motivation
- The app could fail to import the Waveshare e-Paper driver when the Waveshare repository is cloned under the alternate `e-Paper` name instead of `waveshare-lib`, causing `ModuleNotFoundError: No module named waveshare_epd`.
- The shutdown helper duplicated import logic and could fail in the same way when clearing the display.

### Description
- Added `_waveshare_lib_candidates()` to enumerate both `waveshare-lib` and `e-Paper` clone layouts under `RaspberryPi_JetsonNano/python/lib` and updated `ensure_waveshare_path()` to insert any found paths into `sys.path` and return the added paths as a `list[str]`.
- Improved `show_on_epaper()` error messaging to include the candidate locations searched and the expected `PYTHONPATH` suffix to make runtime diagnostics clearer.
- Updated `fpv_board/shutdown.py` to call `ensure_waveshare_path()` before importing the Waveshare module so `python -m fpv_board.shutdown` benefits from the same bootstrap logic.
- Updated `README.md` installation and troubleshooting guidance to mention both possible clone names and added a diagnostic code block to verify `waveshare_epd` import and `sys.path`.

### Testing
- Ran `python -m compileall fpv_board` to validate syntax and bytecode compilation; this succeeded.
- Ran the updater in this environment with `python -m fpv_board.main --config fpv_board/config.json --dry-run`; this run failed due to outbound network/proxy restrictions when contacting Open-Meteo and is unrelated to the import-path change.
- Executed a diagnostic snippet `python - <<'PY' from fpv_board.main import _waveshare_lib_candidates, ensure_waveshare_path; print([str(p) for p in _waveshare_lib_candidates()]); print(ensure_waveshare_path()); PY` which printed the expected candidate paths and returned an empty list of added paths because no Waveshare clone directories exist in this workspace, confirming the discovery logic behaves as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a94d958a083209cb4e01b58328642)