### PR TITLE
Force redraw after shutdown and improve Waveshare driver path handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Install Waveshare Python e-Paper library:
 ```bash
 cd /opt/fpv-board
 # Clone only if the folder is not already present in your checkout
-[ -d waveshare-lib ] || git clone https://github.com/waveshare/e-Paper.git waveshare-lib
+[ -d waveshare-lib ] || [ -d e-Paper ] || git clone https://github.com/waveshare/e-Paper.git waveshare-lib
 
-# Optional for interactive troubleshooting; the app now auto-detects this bundled path when present
+# Optional for interactive troubleshooting; the app auto-detects waveshare-lib and e-Paper clone paths when present
 export PYTHONPATH="/opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib:${PYTHONPATH}"
 
 # Quick verification: should print a module path, not an import error
@@ -122,6 +122,8 @@ python -m fpv_board.shutdown --config /opt/fpv-board/fpv_board/config.json
 
 Use `--clear-only` to clear the panel without powering down, or `--dry-run` to verify behavior without touching hardware.
 
+When the shutdown script clears the display, it also removes the cached display state so the next boot/run forces a redraw instead of skipping as "unchanged."
+
 ## systemd setup
 
 ```bash
@@ -149,6 +151,18 @@ journalctl -u fpv-board.service -n 100 --no-pager
 - **Do not run `pip install lgpio`**: this project uses the Raspberry Pi OS package `python3-lgpio`; pip builds often fail and are unnecessary here.
 - **Wrong pins / BUSY stuck**: verify HAT seated correctly and BUSY maps to GPIO24.
 - **Font missing**: defaults to PIL font automatically; adjust `font_*` paths in config if needed.
-- **Import error for Waveshare module**: confirm `waveshare-lib/RaspberryPi_JetsonNano/python/lib` exists under `/opt/fpv-board` (auto-detected by the app). If running ad-hoc import checks, also export `PYTHONPATH` and run `python -c "import waveshare_epd; print(waveshare_epd.__file__)"`.
+- **Import error for Waveshare module**: confirm either `waveshare-lib/RaspberryPi_JetsonNano/python/lib` or `e-Paper/RaspberryPi_JetsonNano/python/lib` exists under `/opt/fpv-board` (both are auto-detected by the app). If running ad-hoc import checks, also export `PYTHONPATH` and run `python -c "import waveshare_epd; print(waveshare_epd.__file__)"`.
+- **`ModuleNotFoundError: No module named waveshare_epd` despite exported `PYTHONPATH`**: verify there is no newline in your export command and the path exists exactly:
+  ```bash
+  test -d /opt/fpv-board/waveshare-lib/RaspberryPi_JetsonNano/python/lib || \
+  test -d /opt/fpv-board/e-Paper/RaspberryPi_JetsonNano/python/lib
+  python - <<'PY'
+import sys
+print("python:", sys.executable)
+print("has waveshare path:", [p for p in sys.path if "RaspberryPi_JetsonNano/python/lib" in p])
+import waveshare_epd
+print("waveshare_epd:", waveshare_epd.__file__)
+PY
+  ```
 - **`No module named lgpio` in venv**: recreate venv with `python3 -m venv --system-site-packages .venv` so apt package `python3-lgpio` is visible. Also remove pip-installed swig wrappers if present (`pip uninstall -y swig`), because they can shadow `/usr/bin/swig` during builds.
 - **`Failed to add edge detection`**: ensure no duplicate process is already using GPIO, then set `GPIOZERO_PIN_FACTORY=lgpio` (in shell or systemd service) and rerun.

--- a/fpv_board/main.py
+++ b/fpv_board/main.py
@@ -461,11 +461,21 @@ def states_equal(a: dict[str, Any] | None, b: dict[str, Any]) -> bool:
     return a == b
 
 
-def ensure_waveshare_path() -> None:
-    bundled_lib = Path(__file__).resolve().parent.parent / "waveshare-lib" / "RaspberryPi_JetsonNano" / "python" / "lib"
-    bundled_lib_str = str(bundled_lib)
-    if bundled_lib.exists() and bundled_lib_str not in sys.path:
-        sys.path.insert(0, bundled_lib_str)
+def _waveshare_lib_candidates() -> list[Path]:
+    project_root = Path(__file__).resolve().parent.parent
+    repo_names = ("waveshare-lib", "e-Paper")
+    suffix = Path("RaspberryPi_JetsonNano") / "python" / "lib"
+    return [project_root / repo_name / suffix for repo_name in repo_names]
+
+
+def ensure_waveshare_path() -> list[str]:
+    added_paths: list[str] = []
+    for candidate in _waveshare_lib_candidates():
+        candidate_str = str(candidate)
+        if candidate.exists() and candidate_str not in sys.path:
+            sys.path.insert(0, candidate_str)
+            added_paths.append(candidate_str)
+    return added_paths
 
 
 def show_on_epaper(black: Image.Image, red: Image.Image, model_path: str) -> None:
@@ -474,10 +484,11 @@ def show_on_epaper(black: Image.Image, red: Image.Image, model_path: str) -> Non
     try:
         module = __import__(mod_name, fromlist=[attr_name])
     except ModuleNotFoundError as exc:
+        candidate_paths = ", ".join(str(path) for path in _waveshare_lib_candidates())
         raise RuntimeError(
             "Could not import Waveshare driver module. Ensure waveshare-lib is cloned at "
-            "/opt/fpv-board/waveshare-lib or set PYTHONPATH to include "
-            "waveshare-lib/RaspberryPi_JetsonNano/python/lib."
+            f"one of: {candidate_paths} or set PYTHONPATH to include "
+            "<waveshare-clone>/RaspberryPi_JetsonNano/python/lib."
         ) from exc
     epd_factory = getattr(module, attr_name)
     epd = epd_factory() if callable(epd_factory) else getattr(epd_factory, "EPD")()

--- a/fpv_board/shutdown.py
+++ b/fpv_board/shutdown.py
@@ -6,14 +6,16 @@ import argparse
 import logging
 import subprocess
 from pathlib import Path
+from typing import Any
 
-from fpv_board.main import load_config, setup_logging
+from fpv_board.main import ensure_waveshare_path, load_config, setup_logging
 
 
 DEFAULT_CONFIG_PATH = Path("/opt/fpv-board/fpv_board/config.json")
 
 
 def clear_display(model_path: str) -> None:
+    ensure_waveshare_path()
     mod_name, attr_name = model_path.rsplit(".", 1)
     module = __import__(mod_name, fromlist=[attr_name])
     epd_factory = getattr(module, attr_name)
@@ -26,6 +28,15 @@ def clear_display(model_path: str) -> None:
 
 def shutdown_pi() -> None:
     subprocess.run(["sudo", "shutdown", "-h", "now"], check=True)
+
+
+def invalidate_state_cache(cfg: dict[str, Any]) -> None:
+    cache_file = Path(str(cfg["state"]["cache_file"]))
+    try:
+        cache_file.unlink(missing_ok=True)
+        logging.info("Removed cached display state at %s to force refresh on next run", cache_file)
+    except OSError as exc:
+        logging.warning("Unable to remove cached display state %s: %s", cache_file, exc)
 
 
 def parse_args() -> argparse.Namespace:
@@ -57,6 +68,7 @@ def main() -> int:
 
     clear_display(model_path)
     logging.info("Display cleared and put to sleep")
+    invalidate_state_cache(cfg)
 
     if args.clear_only:
         logging.info("Clear-only mode enabled; skipping shutdown")


### PR DESCRIPTION
### Motivation
- The display could remain blank after using the shutdown script because the previous display-state cache made the updater skip a redraw. 
- The Waveshare e-Paper driver can be installed under two common clone names (`waveshare-lib` or `e-Paper`), and the app should detect both to avoid import failures.

### Description
- Added `_waveshare_lib_candidates()` and changed `ensure_waveshare_path()` in `fpv_board/main.py` to discover both `waveshare-lib` and `e-Paper` clone layouts and return any paths added to `sys.path` (now returns `list[str]`).
- Improved `show_on_epaper()` error messaging to include the candidate locations searched and the expected `PYTHONPATH` suffix for clearer diagnostics in `fpv_board/main.py`.
- Added `invalidate_state_cache()` to `fpv_board/shutdown.py` and call it after clearing/sleeping the display so the next run forces a redraw instead of skipping due to stale cached state.
- Ensured `fpv_board/shutdown.py` calls `ensure_waveshare_path()` before importing the Waveshare module and documented the behavior in `README.md` including the additional clone name and a diagnostic snippet.

### Testing
- Ran `python -m compileall fpv_board` to validate syntax and bytecode; this succeeded.
- Ran `python -m fpv_board.shutdown --config fpv_board/config.json --dry-run` to exercise the shutdown dry-run path; this printed expected dry-run messages and succeeded.
- Executed a small snippet exercising `invalidate_state_cache()` with a temporary file and confirmed the cache file was removed; this test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a94d958a083209cb4e01b58328642)