### PR TITLE
Force first display refresh after reboot

### DIFF
--- a/fpv_board/main.py
+++ b/fpv_board/main.py
@@ -21,7 +21,7 @@ import requests
 from PIL import Image, ImageDraw, ImageFont
 
 MS_PER_MPH = 0.44704
-DISPLAY_STATE_VERSION = 2
+DISPLAY_STATE_VERSION = 3
 STATUS_ICON_FILES = {
     "GREAT": "great.png",
     "OK": "ok.png",
@@ -432,6 +432,7 @@ def build_display_state(result: dict[str, Any], cfg: dict[str, Any]) -> dict[str
     w = result.get("worst", {})
     return {
         "version": DISPLAY_STATE_VERSION,
+        "boot_id": current_boot_id(),
         "status": result["status"],
         "reason": result["reason"],
         "trend": result["trend"],
@@ -441,6 +442,14 @@ def build_display_state(result: dict[str, Any], cfg: dict[str, Any]) -> dict[str
         "temp": rounded(float(w.get("temp_min", 0.0)), float(tol["temp_c"])),
         "cloud": rounded(float(w.get("cloud", 0.0)), float(tol["cloud_pct"])),
     }
+
+
+def current_boot_id() -> str:
+    try:
+        return Path("/proc/sys/kernel/random/boot_id").read_text(encoding="utf-8").strip()
+    except OSError:
+        # Fall back so we don't break on systems without procfs.
+        return "unknown"
 
 
 def load_previous_state(cache_file: Path) -> dict[str, Any] | None:


### PR DESCRIPTION
### Motivation
- Ensure the e-paper panel is redrawn once after each system boot so a blanked display from shutdown is updated even if weather values are unchanged.

### Description
- Bump `DISPLAY_STATE_VERSION` to `3` and add a `boot_id` field to the cached display state so change detection treats a new boot as a meaningful change.
- Add `current_boot_id()` which reads `/proc/sys/kernel/random/boot_id` with a safe fallback of `"unknown"` on systems without procfs.

### Testing
- Ran `python -m py_compile fpv_board/main.py` which succeeded. 
- Ran `python fpv_board/main.py --help` which succeeded. 
- Ran `python fpv_board/main.py --config fpv_board/config.json --dry-run` which failed due to outbound network/proxy restrictions contacting the weather API and not due to the change in code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b0fe01cb0832091f3b19ed96b9b2c)