### PR TITLE
Fix local test execution after merge and document test steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ sudo apt install -y python3 python3-venv python3-pip git rsync \
 ```
 
 Then follow the full setup guide in [`docs/README_SETUP.md`](docs/README_SETUP.md).
+
+## Running the test suite
+
+From the repository root:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt pytest
+pytest -q
+```
+
+This project includes a `pytest.ini` that sets the repository root on `PYTHONPATH`, so tests work from a clean checkout without extra environment variables.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
### Motivation
- Recent changes caused test imports to fail from a clean checkout because `PYTHONPATH` was not set, breaking local `pytest` collection.

### Description
- Add a root `pytest.ini` with `pythonpath = .` and update `README.md` with a `Running the test suite` section that shows creating a venv, installing deps, and running `pytest -q`.

### Testing
- Ran `pytest -q`; prior to the change collection failed with import errors, and after the change the full suite succeeded with `9 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c8a79569c8320b3fffe64371ee837)